### PR TITLE
add fallback mechanism to allow grafana agent to use home configuration

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+CONFIG_PATH="$(snapctl get configuration-path)"
+
+# Use fallback configuration mechanism if the configuration-path is set
+if [ -n "${CONFIG_PATH}" ]; then
+    # But always give precedence to the configuration-read plug
+    if snapctl is-connected configuration-read; then
+      logger -t ${SNAP_NAME} "Plug 'configuration-read' is connected, \
+        the configuration-path parameter will be ignored"
+      exit 1
+    fi
+
+    if [ ! -d "/root/${CONFIG_PATH}" ]; then
+        >&2 echo "Error: configuration-path '${CONFIG_PATH}' does not exist. \
+            The path must be relative to root."
+        logger -t ${SNAP_NAME} "Error: configuration-path '${CONFIG_PATH}' does not exist. \
+            The path must be relative to root."
+        exit 1
+    fi
+fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -15,7 +15,7 @@ if [ -n "${CONFIG_PATH}" ]; then
         >&2 echo "Error: configuration-path '${CONFIG_PATH}' does not exist. \
             The path must be relative to root."
         logger -t ${SNAP_NAME} "Error: configuration-path '${CONFIG_PATH}' does not exist. \
-            The path must be relative to root."
+            The path must be relative to `/root`."
         exit 1
     fi
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,5 +1,7 @@
 #!/bin/sh -e
 
+snapctl set configuration-path!
+
 mkdir -p $SNAP_DATA/etc/
 
 if [ ! -f $SNAP_DATA/etc/grafana-agent.yaml ]
@@ -12,4 +14,3 @@ integrations:
     enabled: true
 EOF
 fi
-

--- a/snap/local/agent-wrapper
+++ b/snap/local/agent-wrapper
@@ -2,12 +2,18 @@
 
 IS_CONNECTED=$(snapctl is-connected configuration-read; echo $?)
 
+# Get fallback configuration-path to use in case configuration-read is not plugged
+CONFIG_PATH_PARAMETER="$(snapctl get configuration-path)"
+
 export AGENT_MODE=flow
 
 if [ "${IS_CONNECTED}" = "0" -a -r $SNAP_COMMON/configuration/grafana-agent.river ]
 then
   echo "Launched with config from the content-sharing configuration" | systemd-cat
   exec "${SNAP}/agent" run "$SNAP_COMMON/configuration/grafana-agent.river"
+elif [ -n "${CONFIG_PATH_PARAMETER}" ]; then
+  echo "Launched with config from the root configuration" | systemd-cat
+  exec "${SNAP}/agent" run "/root/${CONFIG_PATH_PARAMETER}/grafana-agent.river"
 else
   echo "Launched with minimal default config from the snap" | systemd-cat
   exec "${SNAP}/agent" run "/etc/grafana-agent.river"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,9 @@ plugs:
       - /proc/sys/kernel/random/read_wakeup_threshold
       - /proc/sys/kernel/random/poolsize
       - /proc/sys/kernel/random/urandom_min_reseed_secs
+hooks:
+  configure:
+    plugs: [home]
 apps:
   grafana-agent:
     daemon: simple
@@ -37,6 +40,7 @@ apps:
     install-mode: disable
     restart-condition: on-failure
     plugs:
+      - home
       - network-bind
       - time-control
       - hardware-observe


### PR DESCRIPTION
Add fallback mechanism to pass the configuration to the grafana-agent.
This snaps rely on the connection to a configuration snap (with a configuration-read plug), to get its configuration. This allows to use the grafana-agent without a configuration snap, by setting a configuration-path parameter.

The path can be set with:

`snap set rob-cos-grafana-agent configuration-path="./configuration"`

before enabling the grafana-agent with `sudo snap start --enable rob-cos-grafana-agent`.
The parameter must be a path in /root, because, in order to preserve automatic registration, the registration happens in the configure hook (whose home is /root).
Precedence is always given to the configuration-read hook.
