### PR TITLE
feat(threads-max): add proc-sys-kernel-threads-max interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,10 @@ plugs:
   logs:
     interface: content
     target: $SNAP/shared-logs
+  proc-sys-kernel-threads-max:
+    interface: system-files
+    read:
+      - /proc/sys/kernel/threads-max
   proc-sys-kernel-random:
     interface: system-files
     read:


### PR DESCRIPTION
Add a `proc-sys-kernel-threads-max` interface to access a specific file.